### PR TITLE
changing deprecated find(first) query to where(first) query for rails 4

### DIFF
--- a/app/models/spree/product_import.rb
+++ b/app/models/spree/product_import.rb
@@ -178,10 +178,7 @@ module Spree
 
       options[:with].each do |field, value|
         variant.send("#{field}=", value) if variant.respond_to?("#{field}=")
-        applicable_option_type = OptionType.find(:first, :conditions => [
-          "lower(presentation) = ? OR lower(name) = ?",
-          field.to_s, field.to_s]
-        )
+        applicable_option_type = OptionType.where("lower(presentation) = ? OR lower(name) = ?",field.to_s, field.to_s).first
         if applicable_option_type.is_a?(OptionType)
           product.option_types << applicable_option_type unless product.option_types.include?(applicable_option_type)
           opt_value = applicable_option_type.option_values.where(["presentation = ? OR name = ?", value, value]).first


### PR DESCRIPTION
Changing query to fix error in Rails 4, the existing query has been deprecated in rails 3.2.

Fixing the following error
`ActiveRecord::RecordNotFound:` Couldn't find all Spree::OptionTypes with 'id': (first, {:conditions=>["lower(presentation) = ? OR lower(name) = ?", "sku", "sku"]}) (found 0 results, but was looking for 2)`
